### PR TITLE
Remove line item gross price (Z#23182406)

### DIFF
--- a/pretix_zugferd/invoice.py
+++ b/pretix_zugferd/invoice.py
@@ -108,8 +108,6 @@ class ZugferdMixin:
             li.product.name = desc.split("\n")[0]
             li.product.description = desc
             # For negative amounts, only the billed quantity may be negative, not the base price per quantity
-            li.agreement.gross.amount = abs(line.net_value).quantize(Decimal("0.0001"))
-            li.agreement.gross.basis_quantity = (Decimal("1.0000"), "C62")
             li.agreement.net.amount = abs(line.net_value).quantize(Decimal("0.0001"))
             li.agreement.net.basis_quantity = (Decimal("1.0000"), "C62")
             li.delivery.billed_quantity = (Decimal("1.0000") * factor, "C62")

--- a/tests/results/cancellation.xml
+++ b/tests/results/cancellation.xml
@@ -49,10 +49,6 @@
 Attendee: Peter</ram:Description>
             </ram:SpecifiedTradeProduct>
             <ram:SpecifiedLineTradeAgreement>
-                <ram:GrossPriceProductTradePrice>
-                    <ram:ChargeAmount>19.3300</ram:ChargeAmount>
-                    <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>
-                </ram:GrossPriceProductTradePrice>
                 <ram:NetPriceProductTradePrice>
                     <ram:ChargeAmount>19.3300</ram:ChargeAmount>
                     <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>

--- a/tests/results/default.xml
+++ b/tests/results/default.xml
@@ -49,10 +49,6 @@
 Attendee: Peter</ram:Description>
             </ram:SpecifiedTradeProduct>
             <ram:SpecifiedLineTradeAgreement>
-                <ram:GrossPriceProductTradePrice>
-                    <ram:ChargeAmount>19.3300</ram:ChargeAmount>
-                    <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>
-                </ram:GrossPriceProductTradePrice>
                 <ram:NetPriceProductTradePrice>
                     <ram:ChargeAmount>19.3300</ram:ChargeAmount>
                     <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>

--- a/tests/results/delivery_date_off.xml
+++ b/tests/results/delivery_date_off.xml
@@ -49,10 +49,6 @@
 Attendee: Peter</ram:Description>
             </ram:SpecifiedTradeProduct>
             <ram:SpecifiedLineTradeAgreement>
-                <ram:GrossPriceProductTradePrice>
-                    <ram:ChargeAmount>19.3300</ram:ChargeAmount>
-                    <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>
-                </ram:GrossPriceProductTradePrice>
                 <ram:NetPriceProductTradePrice>
                     <ram:ChargeAmount>19.3300</ram:ChargeAmount>
                     <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>

--- a/tests/results/paid.xml
+++ b/tests/results/paid.xml
@@ -49,10 +49,6 @@
 Attendee: Peter</ram:Description>
             </ram:SpecifiedTradeProduct>
             <ram:SpecifiedLineTradeAgreement>
-                <ram:GrossPriceProductTradePrice>
-                    <ram:ChargeAmount>19.3300</ram:ChargeAmount>
-                    <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>
-                </ram:GrossPriceProductTradePrice>
                 <ram:NetPriceProductTradePrice>
                     <ram:ChargeAmount>19.3300</ram:ChargeAmount>
                     <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>

--- a/tests/results/tax_code_exempt.xml
+++ b/tests/results/tax_code_exempt.xml
@@ -48,10 +48,6 @@
 Attendee: Peter</ram:Description>
             </ram:SpecifiedTradeProduct>
             <ram:SpecifiedLineTradeAgreement>
-                <ram:GrossPriceProductTradePrice>
-                    <ram:ChargeAmount>23.0000</ram:ChargeAmount>
-                    <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>
-                </ram:GrossPriceProductTradePrice>
                 <ram:NetPriceProductTradePrice>
                     <ram:ChargeAmount>23.0000</ram:ChargeAmount>
                     <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>

--- a/tests/results/tax_code_guess_AU.xml
+++ b/tests/results/tax_code_guess_AU.xml
@@ -48,10 +48,6 @@
 Attendee: Peter</ram:Description>
             </ram:SpecifiedTradeProduct>
             <ram:SpecifiedLineTradeAgreement>
-                <ram:GrossPriceProductTradePrice>
-                    <ram:ChargeAmount>23.0000</ram:ChargeAmount>
-                    <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>
-                </ram:GrossPriceProductTradePrice>
                 <ram:NetPriceProductTradePrice>
                     <ram:ChargeAmount>23.0000</ram:ChargeAmount>
                     <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>

--- a/tests/results/tax_code_reverse_charge.xml
+++ b/tests/results/tax_code_reverse_charge.xml
@@ -48,10 +48,6 @@
 Attendee: Peter</ram:Description>
             </ram:SpecifiedTradeProduct>
             <ram:SpecifiedLineTradeAgreement>
-                <ram:GrossPriceProductTradePrice>
-                    <ram:ChargeAmount>23.0000</ram:ChargeAmount>
-                    <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>
-                </ram:GrossPriceProductTradePrice>
                 <ram:NetPriceProductTradePrice>
                     <ram:ChargeAmount>23.0000</ram:ChargeAmount>
                     <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>

--- a/tests/results/xrechnung.xml
+++ b/tests/results/xrechnung.xml
@@ -46,10 +46,6 @@
 Attendee: Peter</ram:Description>
             </ram:SpecifiedTradeProduct>
             <ram:SpecifiedLineTradeAgreement>
-                <ram:GrossPriceProductTradePrice>
-                    <ram:ChargeAmount>19.3300</ram:ChargeAmount>
-                    <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>
-                </ram:GrossPriceProductTradePrice>
                 <ram:NetPriceProductTradePrice>
                     <ram:ChargeAmount>19.3300</ram:ChargeAmount>
                     <ram:BasisQuantity unitCode="C62">1.0000</ram:BasisQuantity>


### PR DESCRIPTION
"Gross" here means "before allowance". Since we do not list allowances, we do not need the gross price.